### PR TITLE
Install `gcsfuse` into main container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -qq update \
         mbuffer \
         wget \
         git \
+        fuse \
     && rm -rf /var/lib/apt/lists/* \
     && pip install -U --no-cache-dir pip
 
@@ -21,6 +22,12 @@ RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
     && apt-get -qqy --no-install-recommends install \
         mongodb-database-tools \
     && rm -rf /var/lib/apt/lists/*
+
+# Install GCSFuse
+ENV GCSFUSE_VERSION 0.39.2
+RUN wget https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v${GCSFUSE_VERSION}/gcsfuse_${GCSFUSE_VERSION}_amd64.deb \
+    && dpkg --install gcsfuse_${GCSFUSE_VERSION}_amd64.deb \
+    && rm -Rf gcsfuse_${GCSFUSE_VERSION}_amd64.deb
 
 COPY singer-connectors/ /app/singer-connectors/
 COPY Makefile /app


### PR DESCRIPTION
## Problem

When using PipelineWise in GKE it would be nice to be able to use GCS as shared storage between PipelineWise jobs. 

## Proposed changes

GCSFuse can be used to mount a GCS bucket as if it were part of the filesystem to allow for this storage to be used. 

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
