### PR TITLE
Push container image to Thread's DockerHub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -38,6 +38,8 @@ jobs:
         tags: |
           thread/pipelinewise:${{ steps.genTag.outputs.replaced }}
           thread/pipelinewise:latest
+        build-args: |
+          connectors=tap-postgres,target-bigquery,transform-field
 
     - name: Build and push barebone image
       id: docker_build_barebone

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -19,7 +19,7 @@ jobs:
       uses: frabert/replace-string-action@v2.0
       id: genTag
       with:
-        pattern: '.*(\d+\.\d+\.\d+).*'
+        pattern: '.*(\d+\.\d+\.\d+.*).*'
         string: "${{ github.event.release.tag_name }}"
         replace-with: '$1'
 

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -36,8 +36,8 @@ jobs:
         file: ./Dockerfile
         push: true
         tags: |
-          transferwiseworkspace/pipelinewise:${{ steps.genTag.outputs.replaced }}
-          transferwiseworkspace/pipelinewise:latest
+          thread/pipelinewise:${{ steps.genTag.outputs.replaced }}
+          thread/pipelinewise:latest
 
     - name: Build and push barebone image
       id: docker_build_barebone
@@ -46,8 +46,8 @@ jobs:
         file: ./Dockerfile.barebone
         push: true
         tags: |
-          transferwiseworkspace/pipelinewise-barebone:${{ steps.genTag.outputs.replaced }}
-          transferwiseworkspace/pipelinewise-barebone:latest
+          thread/pipelinewise-barebone:${{ steps.genTag.outputs.replaced }}
+          thread/pipelinewise-barebone:latest
 
     - name: Image digests
       run: |


### PR DESCRIPTION
## Problem

We would like to maintain our own versions of the PipelineWise container images.

## Proposed changes

- Push container images to Thread's DockerHub
- Allow Thread specific version tags (ie. `0.0.1.thread`)

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
