### PR TITLE
Allow non-default configuration directory

### DIFF
--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -20,7 +20,7 @@ from ..logger import Logger
 __version__ = get_distribution('pipelinewise').version
 USER_HOME = os.path.expanduser('~')
 DEFAULT_CONFIG_DIR = os.path.join(USER_HOME, '.pipelinewise')
-CONFIG_DIR = os.environ.get('PIPELINEWISE_CONFIG', DEFAULT_CONFIG_DIR)
+CONFIG_DIR = os.environ.get('PIPELINEWISE_CONFIG_DIRECTORY', DEFAULT_CONFIG_DIR)
 PROFILING_DIR = os.path.join(CONFIG_DIR, 'profiling')
 PIPELINEWISE_DEFAULT_HOME = os.path.join(USER_HOME, 'pipelinewise')
 PIPELINEWISE_HOME = os.path.abspath(

--- a/pipelinewise/cli/__init__.py
+++ b/pipelinewise/cli/__init__.py
@@ -19,7 +19,8 @@ from ..logger import Logger
 
 __version__ = get_distribution('pipelinewise').version
 USER_HOME = os.path.expanduser('~')
-CONFIG_DIR = os.path.join(USER_HOME, '.pipelinewise')
+DEFAULT_CONFIG_DIR = os.path.join(USER_HOME, '.pipelinewise')
+CONFIG_DIR = os.environ.get('PIPELINEWISE_CONFIG', DEFAULT_CONFIG_DIR)
 PROFILING_DIR = os.path.join(CONFIG_DIR, 'profiling')
 PIPELINEWISE_DEFAULT_HOME = os.path.join(USER_HOME, 'pipelinewise')
 PIPELINEWISE_HOME = os.path.abspath(


### PR DESCRIPTION
## Problem

- There is currently no way to configure a non-default configuration directory.

## Proposed changes

- Implement an environment variable to override the default.
- The current tests should cover it. 


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
