### PR TITLE
Avoid requiring file metadata

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -931,7 +931,7 @@ class PipelineWise:
         # Tap exists and has log in running status
         elif (
             os.path.isdir(log_dir)
-            and len(utils.search_files(log_dir, patterns=['*.log.running'])) > 0
+            and len(utils.search_log_files(log_dir, patterns=['*.log.running'])) > 0
         ):
             status['currentStatus'] = 'running'
 
@@ -941,7 +941,7 @@ class PipelineWise:
 
         # Get last run instance
         if os.path.isdir(log_dir):
-            log_files = utils.search_files(
+            log_files = utils.search_log_files(
                 log_dir, patterns=['*.log.success', '*.log.failed'], sort=True
             )
             if len(log_files) > 0:
@@ -1016,7 +1016,7 @@ class PipelineWise:
         log_dir = os.path.dirname(self.tap_run_log_file)
         if (
             os.path.isdir(log_dir)
-            and len(utils.search_files(log_dir, patterns=['*.log.running'])) > 0
+            and len(utils.search_log_files(log_dir, patterns=['*.log.running'])) > 0
         ):
             self.logger.info(
                 'Failed to run. Another instance of the same tap is already running. '
@@ -1092,7 +1092,7 @@ class PipelineWise:
         log_dir = os.path.dirname(self.tap_run_log_file)
         if (
             os.path.isdir(log_dir)
-            and len(utils.search_files(log_dir, patterns=['*.log.running'])) > 0
+            and len(utils.search_log_files(log_dir, patterns=['*.log.running'])) > 0
         ):
             self.logger.info(
                 'Failed to run. Another instance of the same tap is already running. '

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -351,22 +351,10 @@ def search_log_files(
         for pattern in patterns:
             p_files.extend(glob.glob(os.path.join(search_dir, pattern)))
         if sort:
-            # We will extract the time of the run from the name
-            # of the log file.
-            timestamp_pattern = re.compile(
-                r'(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})\..+\.log'
+            p_files.sort(
+                key=lambda x: extract_log_attributes(x)['timestamp'],
+                reverse=True,
             )
-            def sort_key(element):
-                match = timestamp_pattern.search(element)
-                return datetime(
-                    year=int(match.group(1)),
-                    month=int(match.group(2)),
-                    day=int(match.group(3)),
-                    hour=int(match.group(4)),
-                    minute=int(match.group(5)),
-                )
-
-            p_files.sort(key=sort_key, reverse=True)
 
         # Cut the whole paths, we only need the filenames
         files = list(map(lambda x: os.path.basename(x) if not abs_path else x, p_files))

--- a/pipelinewise/cli/utils.py
+++ b/pipelinewise/cli/utils.py
@@ -340,7 +340,7 @@ def search_log_files(
     abs_path: bool = False,
 ):
     """
-    Searching log files in a specific directory that match a pattern
+    Searching log files in a specific directory that match a pattern (assumes no sub-directories)
     """
     if patterns is None:
         patterns = ['*']


### PR DESCRIPTION
## Problem

We're seeing issues where PipelineWise start-up time can get up to 20+ minutes. This is due to searching the ever growing list of log files which are stored in GCS.

Since we are using GCSFuse to back the storage it requires an API call to obtain file metadata such as edit time or whether it is a file. This is what is causing the delay - literally hundreds/thousands of API calls to GCS.

## Proposed changes

To avoid this issue we obtain the log time from the file name and don't bother checking whether it is a file (they're all log files so this should be fine assuming no careless human intervention).

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
